### PR TITLE
accounts_db creation & default admin and voter accounts

### DIFF
--- a/src/main/java/org/sysc4907/votingsystem/VotingSystemApplication.java
+++ b/src/main/java/org/sysc4907/votingsystem/VotingSystemApplication.java
@@ -2,11 +2,47 @@ package org.sysc4907.votingsystem;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 @SpringBootApplication
 public class VotingSystemApplication {
 	public static void main(String[] args) {
+		// Create accounts_db if it does not already exist
+		createDB("accounts_db", "postgres", "postgres");
 		SpringApplication.run(VotingSystemApplication.class, args);
+	}
+
+
+	/**
+	 * Creates accounts_db with default username/password if it does not exist.
+	 *
+	 * @param dbName accounts_db
+	 * @param username postgres
+	 * @param password postgres
+	 */
+	private static void createDB(String dbName, String username, String password) {
+		String url = "jdbc:postgresql://localhost:5432/postgres"; // Connect to default DB
+		try (Connection connection = DriverManager.getConnection(url, username, password);
+			 Statement statement = connection.createStatement()) {
+
+			String checkDbQuery = "SELECT 1 FROM pg_database WHERE datname = '" + dbName + "'";
+			var resultSet = statement.executeQuery(checkDbQuery);
+
+			if (!resultSet.next()) {
+				// DB does not exist
+				String createDbQuery = "CREATE DATABASE " + dbName;
+				statement.executeUpdate(createDbQuery);
+				System.out.println("Database '" + dbName + "' created successfully!");
+
+			} else {
+				System.out.println("Database '" + dbName + "' already exists.");
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
 	}
 
 }

--- a/src/main/java/org/sysc4907/votingsystem/generators/AccountGenerationRunner.java
+++ b/src/main/java/org/sysc4907/votingsystem/generators/AccountGenerationRunner.java
@@ -16,6 +16,7 @@ public class AccountGenerationRunner {
     @Bean
     public boolean run() {
         accountGenerator.generateDummyAccounts();
+        accountGenerator.generateDefaultAccounts(); // for testing purposes
         return true;
     }
 

--- a/src/main/java/org/sysc4907/votingsystem/generators/AccountGenerator.java
+++ b/src/main/java/org/sysc4907/votingsystem/generators/AccountGenerator.java
@@ -48,4 +48,17 @@ public class AccountGenerator {
         }
 
     }
+
+    /**
+     * Creates default accounts for testing purposes ONLY.
+     *
+     * Voter Account - username: "voter", password: "voter"
+     * Admin Account - username: "admin", password: "admin"
+     */
+    public void generateDefaultAccounts() {
+        VoterAccount voterAccount = new VoterAccount("voter", "voter");
+        AdminAccount adminAccount = new AdminAccount("admin", "admin");
+        accountRepository.save(voterAccount);
+        accountRepository.save(adminAccount);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=voting-system
 spring.datasource.url=jdbc:postgresql://localhost:5432/accounts_db
+spring.datasource.name=accounts_db
 spring.datasource.username=postgres
 spring.datasource.password=postgres
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## PR type

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [X] Performance Optimization
- [ ] Documentation Update

## Description
<!--
A description of what this PR is, not how it does what it is supposed to do.
-->

- accounts_db gets created when the application is run (if it does not already exist)
- accounts_db gets populated with hardcoded admin/voter accounts

## Related Issues/Tickets
<!--
If this PR is related to a ticket/issue, include it here.
For github issues the format is as follows: "closes #1234" which would automatically close the github issue
For Jira, link the ticket.
-->
- Jira ticket:
- Related Issue #13
- Closes #
## QA Instruction, Screenshots etc...
<!--
Information on how to run/test the changes in the PR.
Include expected/actual results here as well.
-->

1. Delete your accounts_db in postgres if it is currently there
2. Run VotingSystemApplication
3. Go to the homepage http://localhost:8080/home: attempt to login as an Admin: enter "admin", "admin" for the username & password

Note: You will not be able to login as a voter because the election has not yet been configured
**Note: Will add the default election in another PR**

## Added/updated tests?

- [ ] Yes
- [X] No: _replace this line with details on why tests are not included in this PR_

## PR Checklist

- [X] I have rebased this branch against develop/latest
- [X] All the tests are passing
- [X] My commit messages are descriptive and usefull
