### PR TITLE
conect threeBallot to actual election

### DIFF
--- a/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallotController.java
+++ b/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallotController.java
@@ -1,17 +1,34 @@
 package org.sysc4907.votingsystem.Ballots;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.sysc4907.votingsystem.Elections.ElectionService;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Controller
 public class ThreeBallotController {
 
+    @Autowired
+    private ElectionService electionService;
+
+    @GetMapping("/threeBallotTest")
+    public String threeBallotTest(Model model) {
+        ThreeBallot threeBallot = new ThreeBallot(Arrays.asList("foo", "bar", "baz", "quux"));
+        model.addAttribute("threeBallot", threeBallot);
+        model.addAttribute("firstBallotMarks", threeBallot.getFirstBallot().getMarkValues());
+        model.addAttribute("secondBallotMarks", threeBallot.getSecondBallot().getMarkValues());
+        model.addAttribute("thirdBallotMarks", threeBallot.getThirdBallot().getMarkValues());
+        return "three-ballot";
+    }
+
     @GetMapping("/threeBallot")
     public String threeBallot(Model model) {
-        ThreeBallot threeBallot = new ThreeBallot(Arrays.asList("foo", "bar", "baz", "quux"));
+        List<String> candidates = electionService.getElection().getCandidates();
+        ThreeBallot threeBallot = new ThreeBallot(candidates);
         model.addAttribute("threeBallot", threeBallot);
         model.addAttribute("firstBallotMarks", threeBallot.getFirstBallot().getMarkValues());
         model.addAttribute("secondBallotMarks", threeBallot.getSecondBallot().getMarkValues());

--- a/src/main/resources/templates/successful-voter-login.html
+++ b/src/main/resources/templates/successful-voter-login.html
@@ -68,7 +68,7 @@
         <p class="cast-vote-title">Cast Vote</p>
 
         <div style="display: flex; align-items: center; justify-content: center; gap: 10px;">
-            <button type="button" class="election-button" th:text="'Election: ' + ${electionName}"></button>
+            <button type="button" class="election-button" th:text="'Election: ' + ${electionName}" onclick="window.location.href='/threeBallot';"></button>
             <span th:text="'Poll ends ' + ${endDate} + ' at ' + ${endTime}"
                   style="font-size: 14px; color: #555;"></span>
         </div>


### PR DESCRIPTION
## PR type

- [X] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Performance Optimization
- [ ] Documentation Update

## Description
<!--
A description of what this PR is, not how it does what it is supposed to do.
-->
ThreeBallot front-end now uses the info from the actual election and is able to be called from the button shown after successful voter login.

## Related Issues/Tickets
<!--
If this PR is related to a ticket/issue, include it here.
For github issues the format is as follows: "closes #1234" which would automatically close the github issue
For Jira, link the ticket.
-->
- Jira ticket:
- Related Issue #
- Closes #
## QA Instruction, Screenshots etc...
<!--
Information on how to run/test the changes in the PR.
Include expected/actual results here as well.
-->
create and election and login as a voter. Click on the election and you will be redirected to the three ballot page and the candidates will match the ones from the election.


## Added/updated tests?

- [ ] Yes
- [X] No: 

## PR Checklist

- [X] I have rebased this branch against develop/latest
- [X] All the tests are passing
- [X] My commit messages are descriptive and useful
