### PR TITLE
Develop/encrypt order

### DIFF
--- a/src/main/java/org/sysc4907/votingsystem/Ballots/Ballot.java
+++ b/src/main/java/org/sysc4907/votingsystem/Ballots/Ballot.java
@@ -1,14 +1,21 @@
 package org.sysc4907.votingsystem.Ballots;
 
+import java.security.PublicKey;
+import java.util.List;
+import javax.crypto.Cipher;
+import java.security.PrivateKey;
+import java.util.Base64;
+
 public class Ballot {
     private final int id; // may want a helper class to generate these. Must be random and unique.
     private final Marks[] markableBoxes; // true if voting for candidate in that row, false otherwise.
-    private final int candidateOrder; // plain text to start but will need to be encrypted in the future.
+    private final String encryptedCandidateOrder;
+    private final static long moduloNumber = 9999999999999999L; // must be at least the length of the number of candidates
 
-    public Ballot(int id, int numberOfCandidates, int candidateOrder, boolean[] premarkedBoxes) {
+    public Ballot(int id, int numberOfCandidates, int candidateOrder, boolean[] premarkedBoxes, List<PublicKey> orderKeys) {
         this.id = id;
+
         markableBoxes = new Marks[numberOfCandidates];
-        this.candidateOrder = candidateOrder;
         for (int i = 0; i < premarkedBoxes.length; i++) {
             if (premarkedBoxes[i]) {
                 markableBoxes[i] = new Marks(true, true);
@@ -16,6 +23,15 @@ public class Ballot {
                 markableBoxes[i] = new Marks(false, false);
             }
         }
+        String temp = Integer.toString(candidateOrder);
+        for (PublicKey orderKey : orderKeys) {
+            try {
+                temp = encrypt(temp, orderKey);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        this.encryptedCandidateOrder = temp;
     }
 
     /**
@@ -47,8 +63,8 @@ public class Ballot {
         return markableBoxes[box].marked;
     }
 
-    public int getCandidateOrder() {
-        return candidateOrder;
+    public String getEncryptedCandidateOrder() {
+        return encryptedCandidateOrder;
     }
 
     public int getId() {
@@ -81,6 +97,33 @@ public class Ballot {
         public boolean isPremark() {
             return isPremark;
         }
+    }
+
+    public static String encrypt(String data, PublicKey publicKey) throws Exception {
+        data = obfuscateOrder(data);
+        Cipher cipher = Cipher.getInstance("RSA");
+        cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+        byte[] encryptedBytes = cipher.doFinal(data.getBytes());
+        return Base64.getEncoder().encodeToString(encryptedBytes);
+    }
+
+    public static String decrypt(String encryptedData, PrivateKey privateKey) throws Exception {
+        Cipher cipher = Cipher.getInstance("RSA");
+        cipher.init(Cipher.DECRYPT_MODE, privateKey);
+        byte[] decryptedBytes = cipher.doFinal(Base64.getDecoder().decode(encryptedData));
+        return deObfuscateOrder(new String(decryptedBytes));
+    }
+
+    public static String obfuscateOrder(String order) {
+        long temp = Long.parseLong(order);
+        temp = temp + moduloNumber * (int)(Math.random() * 10);
+        return Long.toString(temp);
+    }
+
+    public static String deObfuscateOrder(String order) {
+        long temp = Long.parseLong(order);
+        temp = temp % moduloNumber;
+        return Long.toString(temp);
     }
 }
 

--- a/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallot.java
+++ b/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallot.java
@@ -14,7 +14,7 @@ public class ThreeBallot {
     private final Ballot thirdBallot;
     private final List<String> candidateList = new ArrayList<>();
 
-    public ThreeBallot(List<String> candidates) {
+    public ThreeBallot(List<String> candidates, List<java.security.PublicKey> orderKeys) {
         int numCandidates = candidates.size();
 
         // call order generator
@@ -36,9 +36,9 @@ public class ThreeBallot {
         PremarkGenerator pGen = new PremarkGenerator(numCandidates);
         boolean[][] premarked = pGen.generateMarks();
 
-        firstBallot = new Ballot(id1, numCandidates, candidateOrder, premarked[0]);
-        secondBallot = new Ballot(id2, numCandidates, candidateOrder, premarked[1]);
-        thirdBallot = new Ballot(id3, numCandidates, candidateOrder, premarked[2]);
+        firstBallot = new Ballot(id1, numCandidates, candidateOrder, premarked[0], orderKeys);
+        secondBallot = new Ballot(id2, numCandidates, candidateOrder, premarked[1], orderKeys);
+        thirdBallot = new Ballot(id3, numCandidates, candidateOrder, premarked[2], orderKeys);
     }
 
     public Ballot selectReceipt(int ballotNumber) {
@@ -73,7 +73,7 @@ public class ThreeBallot {
         for (Ballot ballot : List.of(firstBallot, secondBallot, thirdBallot)) {
             Map<String, Object> ballotMap = new HashMap<>();
             ballotMap.put("id", ballot.getId());
-            ballotMap.put("candidateOrder", ballot.getCandidateOrder());
+            ballotMap.put("candidateOrder", ballot.getEncryptedCandidateOrder());
             ballotMap.put("markableBoxes", ballot.getMarkValues());
             ballotsData.add(ballotMap);
         }

--- a/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallotController.java
+++ b/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallotController.java
@@ -2,6 +2,10 @@ package org.sysc4907.votingsystem.Ballots;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.sysc4907.votingsystem.Elections.ElectionService;
@@ -14,7 +18,18 @@ public class ThreeBallotController {
 
     @GetMapping("/threeBallotTest")
     public String threeBallotTest(Model model) {
-        ThreeBallot threeBallot = new ThreeBallot(Arrays.asList("foo", "bar", "baz", "quux"));
+        KeyPairGenerator keyGen = null;
+        ThreeBallot threeBallot;
+        try {
+            keyGen = KeyPairGenerator.getInstance("RSA");
+            keyGen.initialize(2048); // Key size (2048 or higher is recommended)
+            KeyPair keyPair = keyGen.generateKeyPair();
+
+            threeBallot = new ThreeBallot(Arrays.asList("foo", "bar", "baz", "quux"), Collections.singletonList(keyPair.getPublic()));
+
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
         List<Map<String, Object>> attributes = threeBallot.getBallotAttributes();
         model.addAttribute("attributes", attributes);
         model.addAttribute("threeBallot", threeBallot);
@@ -27,7 +42,7 @@ public class ThreeBallotController {
     @GetMapping("/threeBallot")
     public String threeBallot(Model model) {
         List<String> candidates = electionService.getElection().getCandidates();
-        ThreeBallot threeBallot = new ThreeBallot(candidates);
+        ThreeBallot threeBallot = new ThreeBallot(candidates, electionService.getPublicOrderKeys());
         List<Map<String, Object>> attributes = threeBallot.getBallotAttributes();
         model.addAttribute("attributes", attributes);
         model.addAttribute("threeBallot", threeBallot);

--- a/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallotController.java
+++ b/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallotController.java
@@ -18,7 +18,7 @@ public class ThreeBallotController {
 
     @GetMapping("/threeBallotTest")
     public String threeBallotTest(Model model) {
-        KeyPairGenerator keyGen = null;
+        KeyPairGenerator keyGen;
         ThreeBallot threeBallot;
         try {
             keyGen = KeyPairGenerator.getInstance("RSA");

--- a/src/main/java/org/sysc4907/votingsystem/Elections/ElectionService.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/ElectionService.java
@@ -7,8 +7,11 @@ import org.springframework.web.multipart.MultipartFile;
 import org.sysc4907.votingsystem.Accounts.AccountService;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 
 /**
  * Service class responsible for logic of processing poll configuration.
@@ -19,9 +22,23 @@ public class ElectionService {
     private final AccountService accountService;
     private Set<Integer> voterKeysList;
     private List<String> candidatesList;
+    private final List<java.security.PrivateKey> privateOrderKeys = new ArrayList<>();
+    private final List<java.security.PublicKey> publicOrderKeys = new ArrayList<>();
 
     public ElectionService(AccountService accountService) {
         this.accountService = accountService;
+
+        KeyPairGenerator keyGen = null;
+        try {
+            keyGen = KeyPairGenerator.getInstance("RSA");
+            keyGen.initialize(2048); // Key size (2048 or higher is recommended)
+            KeyPair keyPair = keyGen.generateKeyPair();
+            privateOrderKeys.add(keyPair.getPrivate());
+            publicOrderKeys.add(keyPair.getPublic());
+
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public boolean createElection(ElectionForm electionForm) {
@@ -150,6 +167,9 @@ public class ElectionService {
         }
         return keysList;
     }
+
+    public List<java.security.PublicKey> getPublicOrderKeys() {return publicOrderKeys;}
+    public List<java.security.PrivateKey> getPrivateOrderKeys() {return privateOrderKeys;}
 }
 
 

--- a/src/main/java/org/sysc4907/votingsystem/Elections/ElectionService.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/ElectionService.java
@@ -28,7 +28,7 @@ public class ElectionService {
     public ElectionService(AccountService accountService) {
         this.accountService = accountService;
 
-        KeyPairGenerator keyGen = null;
+        KeyPairGenerator keyGen;
         try {
             keyGen = KeyPairGenerator.getInstance("RSA");
             keyGen.initialize(2048); // Key size (2048 or higher is recommended)

--- a/src/test/java/org/sysc4907/votingsystem/BallotTest.java
+++ b/src/test/java/org/sysc4907/votingsystem/BallotTest.java
@@ -20,8 +20,7 @@ public class BallotTest {
 
     @BeforeEach
     public void setUp() {
-        KeyPairGenerator keyGen = null;
-        ThreeBallot threeBallot;
+        KeyPairGenerator keyGen;
         try {
             keyGen = KeyPairGenerator.getInstance("RSA");
             keyGen.initialize(2048); // Key size (2048 or higher is recommended)
@@ -71,7 +70,7 @@ public class BallotTest {
     }
 
     @Test
-    public void testOrderObfuscation() throws Exception {
+    public void testOrderObfuscation() {
         int order = 132;
         int moduloNumber = 555;
         int obfuscated = order + 555 * (int)(Math.random() * 10);

--- a/src/test/java/org/sysc4907/votingsystem/BallotTest.java
+++ b/src/test/java/org/sysc4907/votingsystem/BallotTest.java
@@ -2,23 +2,44 @@ package org.sysc4907.votingsystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sysc4907.votingsystem.Ballots.Ballot;
+import org.sysc4907.votingsystem.Ballots.ThreeBallot;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BallotTest {
 
     private Ballot b1;
+    private java.security.PrivateKey privateKey;
+    private java.security.PublicKey publicKey;
+
 
     @BeforeEach
     public void setUp() {
-        b1 = new Ballot(1, 3, 231, new boolean[]{false, false, true});
+        KeyPairGenerator keyGen = null;
+        ThreeBallot threeBallot;
+        try {
+            keyGen = KeyPairGenerator.getInstance("RSA");
+            keyGen.initialize(2048); // Key size (2048 or higher is recommended)
+            KeyPair keyPair = keyGen.generateKeyPair();
+            privateKey = keyPair.getPrivate();
+            publicKey = keyPair.getPublic();
+            b1 = new Ballot(1, 3, 231, new boolean[]{false, false, true},  Collections.singletonList(keyPair.getPublic()));
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+
 
     }
 
     @Test
-    public void testBallot() {
+    public void testBallot() throws Exception {
         assertEquals(b1.getId(), 1);
-        assertEquals(b1.getCandidateOrder(), 231);
+        assertEquals("231", Ballot.decrypt(b1.getEncryptedCandidateOrder(), privateKey));
         assertEquals(3, b1.getMarkValues().length);
         assertFalse(b1.getMarkValues()[0]);
         assertFalse(b1.getMarkValues()[1]);
@@ -39,5 +60,23 @@ public class BallotTest {
         b1.setMarkableBox(2, false);
         assertTrue(b1.isBoxMarked(2));
         assertTrue(b1.isPremark(2));
+    }
+
+    @Test
+    public void testEncryptAndDecrypt() throws Exception {
+        String data = "54321";
+        String encrypted = Ballot.encrypt(data, publicKey);
+        String decrypted = Ballot.decrypt(encrypted, privateKey);
+        assertEquals(data, decrypted);
+    }
+
+    @Test
+    public void testOrderObfuscation() throws Exception {
+        int order = 132;
+        int moduloNumber = 555;
+        int obfuscated = order + 555 * (int)(Math.random() * 10);
+        int deObfuscated = obfuscated % moduloNumber;
+
+        assertEquals(132, deObfuscated);
     }
 }

--- a/src/test/java/org/sysc4907/votingsystem/ThreeBallotTest.java
+++ b/src/test/java/org/sysc4907/votingsystem/ThreeBallotTest.java
@@ -3,6 +3,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sysc4907.votingsystem.Ballots.Ballot;
 import org.sysc4907.votingsystem.Ballots.ThreeBallot;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -14,7 +16,7 @@ public class ThreeBallotTest {
 
     @BeforeEach
     public void setUp() {
-        threeBallot = new ThreeBallot(Arrays.asList("foo", "bar", "baz", "qux"));
+        threeBallot = new ThreeBallot(Arrays.asList("foo", "bar", "baz", "qux"), new ArrayList<>());
     }
 
     @Test
@@ -28,21 +30,21 @@ public class ThreeBallotTest {
         assertEquals(4, b3.getMarkValues().length);
 
         // candidate order is 4 digits and contains 1, 2, 3, 4 in any order
-        String candidateOrder1 = String.valueOf(b1.getCandidateOrder());
+        String candidateOrder1 = String.valueOf(b1.getEncryptedCandidateOrder());
         assertEquals(4, candidateOrder1.length());
         assertTrue(candidateOrder1.contains("1"));
         assertTrue(candidateOrder1.contains("2"));
         assertTrue(candidateOrder1.contains("3"));
         assertTrue(candidateOrder1.contains("4"));
 
-        String candidateOrder2 = String.valueOf(b2.getCandidateOrder());
+        String candidateOrder2 = String.valueOf(b2.getEncryptedCandidateOrder());
         assertEquals(4, candidateOrder2.length());
         assertTrue(candidateOrder2.contains("1"));
         assertTrue(candidateOrder2.contains("2"));
         assertTrue(candidateOrder2.contains("3"));
         assertTrue(candidateOrder2.contains("4"));
 
-        String candidateOrder3 = String.valueOf(b3.getCandidateOrder());
+        String candidateOrder3 = String.valueOf(b3.getEncryptedCandidateOrder());
         assertEquals(4, candidateOrder3.length());
         assertTrue(candidateOrder3.contains("1"));
         assertTrue(candidateOrder3.contains("2"));


### PR DESCRIPTION
## PR type

- [X] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Performance Optimization
- [ ] Documentation Update

## Description
<!--
A description of what this PR is, not how it does what it is supposed to do.
-->
Candidate order is now encrypted and the encryption result is different on each ballot while still decrypting to the correct number.

for convenience both public and private keys are being stored in election services. The real way this would work is that the election would hold the public keys while the private keys would be kept by the nodes hosting the election. 

## Related Issues/Tickets
<!--
If this PR is related to a ticket/issue, include it here.
For github issues the format is as follows: "closes #1234" which would automatically close the github issue
For Jira, link the ticket.
-->
- Jira ticket:
- Related Issue #
- Closes #
## QA Instruction, Screenshots etc...
<!--
Information on how to run/test the changes in the PR.
Include expected/actual results here as well.
-->
run app
go to http://localhost:8080/threeBallotTest
encryption will show on the ballot receipt.

![image](https://github.com/user-attachments/assets/5e7a6c0e-e051-459d-9fc5-d154309c0214)


## Added/updated tests?

- [X] Yes
- [ ] No: _replace this line with details on why tests are not included in this PR_

## PR Checklist

- [X] I have rebased this branch against develop/latest
- [X] All the tests are passing
- [X] My commit messages are descriptive and usefull
