### PR TITLE
tally front end

### DIFF
--- a/src/main/java/org/sysc4907/votingsystem/Elections/Election.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/Election.java
@@ -1,6 +1,7 @@
 package org.sysc4907.votingsystem.Elections;
 
 import org.json.JSONArray;
+import org.springframework.core.env.Environment;
 import org.sysc4907.votingsystem.generators.BallotIdGenerator;
 import org.sysc4907.votingsystem.generators.CandidateOrderGenerator;
 
@@ -12,7 +13,7 @@ import java.time.*;
 import java.util.*;
 
 public class Election {
-    private boolean fabricEnabled = true;
+    private boolean fabricEnabled = false;
 
     private int numberOfVotes;
     private Long id;
@@ -30,15 +31,16 @@ public class Election {
 
     private final Set<Integer> voterKeys;
 
-    public Election(LocalDateTime startDateTime, LocalDateTime endDateTime, String name, List<String> candidates, Set<Integer> voterKeys) {
+    public Election(Environment environment, LocalDateTime startDateTime, LocalDateTime endDateTime, String name, List<String> candidates, Set<Integer> voterKeys) {
         START_DATE_TIME = startDateTime;
         END_DATE_TIME = endDateTime;
         NAME = name;
         this.candidates = List.copyOf(candidates);
         this.voterKeys = voterKeys;
-        tallier = new Tally(candidates.size());
+        tallier = new Tally(environment, candidates.size());
         this.candidateOrderGenerator = new CandidateOrderGenerator(candidates.size());
         this.numberOfVotes = 0;
+        fabricEnabled = environment.getProperty("fabric.enabled", Boolean.class, true);
     }
 
     public Election() {
@@ -47,7 +49,7 @@ public class Election {
         NAME = "";
         candidates = new ArrayList<>();
         voterKeys = new HashSet<>();
-        tallier = new Tally(0);
+        tallier = new Tally();
         candidateOrderGenerator = new CandidateOrderGenerator(0);
     }
 

--- a/src/main/java/org/sysc4907/votingsystem/Elections/Election.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/Election.java
@@ -184,7 +184,7 @@ public class Election {
         }
         try {
             // Specify the endpoint URL
-            String endpoint = "https://localhost:8080/fabric/evaluate?evaluate?function=GetAllBallots";
+            String endpoint = "http://localhost:8080/fabric/evaluate?function=GetAllBallots";
 
             // Create a URL object
             URL url = new URL(endpoint);

--- a/src/main/java/org/sysc4907/votingsystem/Elections/Election.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/Election.java
@@ -1,7 +1,6 @@
 package org.sysc4907.votingsystem.Elections;
 
 import org.json.JSONArray;
-import org.springframework.beans.factory.annotation.Value;
 import org.sysc4907.votingsystem.generators.BallotIdGenerator;
 import org.sysc4907.votingsystem.generators.CandidateOrderGenerator;
 
@@ -13,6 +12,7 @@ import java.time.*;
 import java.util.*;
 
 public class Election {
+    private boolean fabricEnabled = true;
 
     private int numberOfVotes;
     private Long id;
@@ -29,9 +29,6 @@ public class Election {
     private final CandidateOrderGenerator candidateOrderGenerator;
 
     private final Set<Integer> voterKeys;
-
-    @Value("${fabric.enabled}")
-    private boolean fabricEnabled;
 
     public Election(LocalDateTime startDateTime, LocalDateTime endDateTime, String name, List<String> candidates, Set<Integer> voterKeys) {
         START_DATE_TIME = startDateTime;

--- a/src/main/java/org/sysc4907/votingsystem/Elections/Election.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/Election.java
@@ -184,7 +184,7 @@ public class Election {
         }
         try {
             // Specify the endpoint URL
-            String endpoint = "https://api.example.com/data";
+            String endpoint = "https://localhost:8080/fabric/evaluate?evaluate?function=GetAllBallots";
 
             // Create a URL object
             URL url = new URL(endpoint);

--- a/src/main/java/org/sysc4907/votingsystem/Elections/ElectionController.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/ElectionController.java
@@ -70,10 +70,7 @@ public class ElectionController {
             model.addAttribute("postElection", election.END_DATE_TIME.isBefore(now));
 
             model.addAttribute("numVotesCast", electionService.getNumVotesCast());
-
-            if (election.END_DATE_TIME.isBefore(now)) {
                 model.addAttribute("tally", electionService.getTally());
-            }
 
             System.out.println(model.getAttribute("isLoggedIn"));
             System.out.println(election.END_DATE_TIME);

--- a/src/main/java/org/sysc4907/votingsystem/Elections/ElectionController.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/ElectionController.java
@@ -69,6 +69,12 @@ public class ElectionController {
             model.addAttribute("currentCountdown", election.getElectionCountdown());
             model.addAttribute("postElection", election.END_DATE_TIME.isBefore(now));
 
+            model.addAttribute("numVotesCast", electionService.getNumVotesCast());
+
+            if (election.END_DATE_TIME.isBefore(now)) {
+                model.addAttribute("tally", electionService.getTally());
+            }
+
             System.out.println(model.getAttribute("isLoggedIn"));
             System.out.println(election.END_DATE_TIME);
 

--- a/src/main/java/org/sysc4907/votingsystem/Elections/ElectionService.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/ElectionService.java
@@ -173,6 +173,14 @@ public class ElectionService {
         return keysList;
     }
 
+    public List<Integer> getTally() {
+        return election.tallyOfVotes(privateOrderKeys);
+    }
+
+    public int getNumVotesCast() {
+        return election.numVotesCast();
+    }
+
     public List<java.security.PublicKey> getPublicOrderKeys() {return publicOrderKeys;}
     public List<java.security.PrivateKey> getPrivateOrderKeys() {return privateOrderKeys;}
 }

--- a/src/main/java/org/sysc4907/votingsystem/Elections/ElectionService.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/ElectionService.java
@@ -1,5 +1,7 @@
 package org.sysc4907.votingsystem.Elections;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,9 +26,12 @@ public class ElectionService {
     private List<String> candidatesList;
     private final List<java.security.PrivateKey> privateOrderKeys = new ArrayList<>();
     private final List<java.security.PublicKey> publicOrderKeys = new ArrayList<>();
+    Environment environment;
 
-    public ElectionService(AccountService accountService) {
+    @Autowired
+    public ElectionService(AccountService accountService,  Environment environment) {
         this.accountService = accountService;
+        this.environment = environment;
 
         KeyPairGenerator keyGen;
         try {
@@ -42,7 +47,7 @@ public class ElectionService {
     }
 
     public boolean createElection(ElectionForm electionForm) {
-        election = new Election(electionForm.getStartDateTime(), electionForm.getEndDateTime(), electionForm.getName(), candidatesList, voterKeysList);
+        election = new Election(environment, electionForm.getStartDateTime(), electionForm.getEndDateTime(), electionForm.getName(), candidatesList, voterKeysList);
         accountService.initAccountService(new HashSet<>(voterKeysList));
         // generate public & private keys
         LirisiCommandExecutor executor = new LirisiCommandExecutor();

--- a/src/main/java/org/sysc4907/votingsystem/Elections/Tally.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/Tally.java
@@ -2,7 +2,6 @@ package org.sysc4907.votingsystem.Elections;
 
 
 import org.json.JSONArray;
-import org.springframework.beans.factory.annotation.Value;
 import org.sysc4907.votingsystem.Ballots.Ballot;
 
 import org.json.JSONObject;
@@ -15,8 +14,7 @@ public class Tally {
     private final List<Integer> tallyOfVotes = new ArrayList<>();
     private final List<Integer> tallyOfVotesAdjusted = new ArrayList<>(); // Adjusted to compensate for three ballot system
 
-    @Value("${fabric.enabled}")
-    private boolean fabricEnabled;
+    private boolean fabricEnabled = true;
 
     public Tally(int numCandidates) {
         for (int i = 0; i < numCandidates; i++) {

--- a/src/main/java/org/sysc4907/votingsystem/Elections/Tally.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/Tally.java
@@ -2,6 +2,7 @@ package org.sysc4907.votingsystem.Elections;
 
 
 import org.json.JSONArray;
+import org.springframework.core.env.Environment;
 import org.sysc4907.votingsystem.Ballots.Ballot;
 
 import org.json.JSONObject;
@@ -14,13 +15,16 @@ public class Tally {
     private final List<Integer> tallyOfVotes = new ArrayList<>();
     private final List<Integer> tallyOfVotesAdjusted = new ArrayList<>(); // Adjusted to compensate for three ballot system
 
-    private boolean fabricEnabled = true;
+    private boolean fabricEnabled = false;
 
-    public Tally(int numCandidates) {
+    public Tally(Environment environment, int numCandidates) {
+        fabricEnabled = environment.getProperty("fabric.enabled", Boolean.class, true);
         for (int i = 0; i < numCandidates; i++) {
             tallyOfVotes.add(0);
         }
     }
+
+    public Tally() {}
 
     public List<Integer> tallyVotes(JSONArray jsonArray, List<PrivateKey> privateKeys) {
 

--- a/src/main/resources/templates/election-details.html
+++ b/src/main/resources/templates/election-details.html
@@ -170,7 +170,7 @@
             </tr>
             <tr th:if="!${currentCountdown}">
                 <th># of Votes</th>
-                <td th:text="${election.getNumberOfVotes()}"></td>
+                <td th:text="${election.numVotesCast()}"></td>
             </tr>
         </table>
 
@@ -192,21 +192,35 @@
 </body>
 <script th:inline="javascript">
     /*<![CDATA[*/
-    /* Check if the election object is defined */
-    var candidates = /*[[${election != null ? election.getVotingResults() : {}}]]*/;
-
-    if (Object.keys(candidates).length > 0) {
-        // Extract candidate names and vote tallies
-        var candidateNames = Object.keys(candidates);
-        var voteTallies = Object.values(candidates);
-
-        // Now you can use candidateNames and voteTallies in your charts
-        console.log(candidateNames);  // Candidate names
-        console.log(voteTallies);     // Vote tallies
-    } else {
-        console.warn("Election data is not available.");
-    }
+    const tallyOfVotes = /*[[${tally}]]*/ [];
+    const candidates = /*[[${election.getCandidates}]]*/ [];
     /*]]>*/
+
+    // Bar Chart
+    const barCtx = document.getElementById('barChart').getContext('2d');
+    new Chart(barCtx, {
+        type: 'bar',
+        data: {
+            labels: candidates,
+            datasets: [{
+                label: 'Votes',
+                data: tallyOfVotes
+            }]
+        }
+    });
+
+    // Pie Chart
+    const pieCtx = document.getElementById('pieChart').getContext('2d');
+    new Chart(pieCtx, {
+        type: 'pie',
+        data: {
+            labels: candidates,
+            datasets: [{
+                label: 'Votes',
+                data: tallyOfVotes
+            }]
+        }
+    });
 </script>
 
 <script>
@@ -216,10 +230,10 @@
     var barChart = new Chart(barChartContext, {
         type: 'bar',
         data: {
-            labels: candidateNames,
+            labels: candidates,
             datasets: [{
                 label: 'Votes',
-                data: voteTallies,
+                data: tallyOfVotes,
                 backgroundColor: 'rgba(54, 162, 235, 0.2)',
                 borderColor: 'rgba(54, 162, 235, 1)',
                 borderWidth: 1
@@ -241,10 +255,10 @@
     var pieChart = new Chart(pieChartContext, {
         type: 'pie',
         data: {
-            labels: candidateNames,
+            labels: candidates,
             datasets: [{
                 label: 'Votes',
-                data: voteTallies,
+                data: tallyOfVotes,
                 backgroundColor: [
                     'rgba(255, 99, 132, 0.2)',
                     'rgba(54, 162, 235, 0.2)',

--- a/src/test/java/org/sysc4907/votingsystem/ElectionServiceTest.java
+++ b/src/test/java/org/sysc4907/votingsystem/ElectionServiceTest.java
@@ -42,7 +42,7 @@ public class ElectionServiceTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        electionService = new ElectionService(accountService);
+        electionService = new ElectionService(accountService, null);
         bindingResult = mock(BindingResult.class);
         doNothing().when(bindingResult).rejectValue(anyString(), anyString(), anyString());
         mockFile = mock(MultipartFile.class);

--- a/src/test/java/org/sysc4907/votingsystem/TallyTest.java
+++ b/src/test/java/org/sysc4907/votingsystem/TallyTest.java
@@ -3,9 +3,6 @@ package org.sysc4907.votingsystem;
 import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.sysc4907.votingsystem.Accounts.AccountService;
-import org.sysc4907.votingsystem.Elections.Election;
-import org.sysc4907.votingsystem.Elections.ElectionService;
 import org.sysc4907.votingsystem.Elections.Tally;
 import org.json.JSONObject;
 import org.json.JSONArray;
@@ -17,15 +14,19 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class TallyTest {
     Tally tally;
-    String jsonString = "[{\"ballotId\":\"1\",\"ballotMarks\":\"[true,false]\",\"candidateOrder\":\"10\",\"ring\":\"31\"}," +
-                        "{\"ballotId\":\"2\",\"ballotMarks\":\"[true,true]\",\"candidateOrder\":\"10\",\"ring\":\"31\"}," +
-                        "{\"ballotId\":\"3\",\"ballotMarks\":\"[false,false]\",\"candidateOrder\":\"10\",\"ring\":\"31\"}]";
+    String jsonString = "[" +
+            "{\"ballotId\":\"1\",\"ballotMarks\":\"[true,false,true]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
+            "{\"ballotId\":\"2\",\"ballotMarks\":\"[true,true,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
+            "{\"ballotId\":\"3\",\"ballotMarks\":\"[false,false,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
+            "{\"ballotId\":\"4\",\"ballotMarks\":\"[true,true,true]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
+            "{\"ballotId\":\"5\",\"ballotMarks\":\"[false,true,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
+            "{\"ballotId\":\"6\",\"ballotMarks\":\"[false,false,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}]";
     JSONArray mockTransactions = new JSONArray(jsonString);
     List<java.security.PrivateKey> privateKeys = new ArrayList<>();
-    List<String> candidateList = new ArrayList<>(Arrays.asList("foo", "bar"));
-    Tally.CastBallot ballot1 = new Tally.CastBallot(1, new ArrayList<>(Arrays.asList(true, false)), new ArrayList<>(Arrays.asList(1, 0)), new ArrayList<>());
-    Tally.CastBallot ballot2 = new Tally.CastBallot(2, new ArrayList<>(Arrays.asList(true, true)), new ArrayList<>(Arrays.asList(1, 0)), new ArrayList<>());
-    Tally.CastBallot ballot3 = new Tally.CastBallot(3, new ArrayList<>(Arrays.asList(false, false)), new ArrayList<>(Arrays.asList(1, 0)), new ArrayList<>());
+    List<String> candidateList = new ArrayList<>(Arrays.asList("foo", "bar", "baz"));
+    Tally.CastBallot ballot1 = new Tally.CastBallot(1, new ArrayList<>(Arrays.asList(true, false, true)), new ArrayList<>(Arrays.asList(1, 0, 2)), new ArrayList<>());
+    Tally.CastBallot ballot2 = new Tally.CastBallot(2, new ArrayList<>(Arrays.asList(true, true, false)), new ArrayList<>(Arrays.asList(1, 0, 2)), new ArrayList<>());
+    Tally.CastBallot ballot3 = new Tally.CastBallot(3, new ArrayList<>(Arrays.asList(false, false, false)), new ArrayList<>(Arrays.asList(1, 0, 2)), new ArrayList<>());
 
     public TallyTest() throws JSONException {
     }
@@ -37,20 +38,20 @@ public class TallyTest {
 
     @Test
     public void testNumVotesCast() {
-        assertEquals(1, tally.totalNumVotes(mockTransactions));
+        assertEquals(2, tally.totalNumVotes(mockTransactions));
     }
 
     @Test
     public void testTally() {
         List<Integer> totals = tally.tallyVotes(mockTransactions, privateKeys);
-        assertEquals(2, totals.size());
+        assertEquals(3, totals.size());
         assertEquals(1, totals.get(0));
-        assertEquals(0, totals.get(1));
+        assertEquals(1, totals.get(1));
+        assertEquals(0, totals.get(2));
     }
 
     @Test
     public void testGetCastBallot() throws JSONException {
-        System.out.println(mockTransactions.length());
         List<Tally.CastBallot> ballots = new ArrayList<>();
         for (int i = 0; i < mockTransactions.length(); i++) {
             JSONObject jsonTransaction = mockTransactions.getJSONObject(i); // Get JSONObject at index i

--- a/src/test/java/org/sysc4907/votingsystem/TallyTest.java
+++ b/src/test/java/org/sysc4907/votingsystem/TallyTest.java
@@ -3,6 +3,9 @@ package org.sysc4907.votingsystem;
 import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
 import org.sysc4907.votingsystem.Elections.Tally;
 import org.json.JSONObject;
 import org.json.JSONArray;
@@ -11,8 +14,10 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-
+@SpringBootTest
 public class TallyTest {
+    @Autowired
+    private Environment environment;
     Tally tally;
     String jsonString = "[" +
             "{\"ballotId\":\"1\",\"ballotMarks\":\"[true,false,true]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
@@ -33,7 +38,7 @@ public class TallyTest {
 
     @BeforeEach
     public void setUpBeforeClass() {
-        tally = new Tally(candidateList.size());
+        tally = new Tally(environment, candidateList.size());
     }
 
     @Test


### PR DESCRIPTION
## PR type

- [X] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Performance Optimization
- [ ] Documentation Update

## Description
<!--
A description of what this PR is, not how it does what it is supposed to do.
-->
details of an election now get the number of votes cast from the election. after an election is finished tally of votes is now displayed with the count from the election.
if fabric is disabled this will run with mocked data.

## Related Issues/Tickets
<!--
If this PR is related to a ticket/issue, include it here.
For github issues the format is as follows: "closes #1234" which would automatically close the github issue
For Jira, link the ticket.
-->
- Jira ticket:
- Related Issue #
- Closes #
## QA Instruction, Screenshots etc...
<!--
Information on how to run/test the changes in the PR.
Include expected/actual results here as well.
-->
run app
go to http://localhost:8080/test-elections to have an election auto generated.
click on past election to see data. for values to change fabric must be enabled.
![image](https://github.com/user-attachments/assets/be6ae307-c850-492f-9100-af97b814e214)


## Added/updated tests?

- [X] Yes
- [ ] No: _replace this line with details on why tests are not included in this PR_

## PR Checklist

- [X] I have rebased this branch against develop/latest
- [X] All the tests are passing
- [X] My commit messages are descriptive and usefull
