### PR TITLE
Throttling: X login attempts per minute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
 			<artifactId>org.everit.json.schema</artifactId>
 			<version>1.14.4</version>
 		</dependency>
+		<dependency>
+			<groupId>com.bucket4j</groupId>
+			<artifactId>bucket4j_jdk17-core</artifactId>
+			<version>8.14.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/sysc4907/votingsystem/Authentication/RateLimiter.java
+++ b/src/main/java/org/sysc4907/votingsystem/Authentication/RateLimiter.java
@@ -1,0 +1,28 @@
+package org.sysc4907.votingsystem.Authentication;
+
+import io.github.bucket4j.Bucket;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.time.Duration;
+
+public class RateLimiter {
+    private static final int TOKENS_PER_MINUTE = 3;
+    private static final Duration REFILL_DURATION = Duration.ofMinutes(1);
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    private Bucket createNewBucket() { // 3 tokens per minute
+        return Bucket.builder()
+                .addLimit(limit -> limit.capacity(TOKENS_PER_MINUTE).refillIntervally(TOKENS_PER_MINUTE, REFILL_DURATION))
+                .build();
+    }
+
+    public boolean tryConsume(String userId) {
+        Bucket bucket = buckets.computeIfAbsent(userId, k -> createNewBucket());
+        return bucket.tryConsume(1);
+    }
+
+    public long getAvailableTokens(String userId) {
+        return buckets.getOrDefault(userId, createNewBucket()).getAvailableTokens();
+    }
+}

--- a/src/main/java/org/sysc4907/votingsystem/Authentication/RateLimiter.java
+++ b/src/main/java/org/sysc4907/votingsystem/Authentication/RateLimiter.java
@@ -25,4 +25,8 @@ public class RateLimiter {
     public long getAvailableTokens(String userId) {
         return buckets.getOrDefault(userId, createNewBucket()).getAvailableTokens();
     }
+
+    public void resetBucket(String userId) {
+        buckets.put(userId, createNewBucket());
+    }
 }


### PR DESCRIPTION
## PR type

- [X] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Performance Optimization
- [ ] Documentation Update

## Description
<!--
A description of what this PR is, not how it does what it is supposed to do.
-->

## Related Issues/Tickets
<!--
If this PR is related to a ticket/issue, include it here.
For github issues the format is as follows: "closes #1234" which would automatically close the github issue
For Jira, link the ticket.
-->
- Jira ticket:
- Related Issue #
- Closes #
## QA Instruction, Screenshots etc...
<!--
Information on how to run/test the changes in the PR.
Include expected/actual results here as well.
-->

http://localhost:8080/home

Attempt to log in as a voter with an incorrect password
Should give 4 attempts before error message is displayed

![Screen Shot 2025-01-31 at 12 14 32 AM](https://github.com/user-attachments/assets/a63012c7-6a1b-47a9-8f20-364200d4851c)

![Screen Shot 2025-01-31 at 12 14 51 AM](https://github.com/user-attachments/assets/ef953c65-baab-4868-a102-642e55fddb5d)

**Note**: With bucket4j the "bucket" gets filled after the first token is consumed. So technically the user may not have to wait a full minute. I would need to add custom logic that would make the library useless.

Also, it doesn't actually prevent the endpoint from being hit, just stops the authentication logic from executing. Therefore, slows down hackers from guessing passwords. 
Can look into adding protection at the network level. 

## Added/updated tests?

- [ ] Yes
- [X] No: _replace this line with details on why tests are not included in this PR_

## PR Checklist

- [X] I have rebased this branch against develop/latest
- [X] All the tests are passing
- [X] My commit messages are descriptive and usefull
