### PR TITLE
[Test on Blockchain] store candidate order with salt.

### DIFF
--- a/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallot.java
+++ b/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallot.java
@@ -19,20 +19,20 @@ public class ThreeBallot {
 
         // call order generator
         CandidateOrderGenerator cGen = new CandidateOrderGenerator(numCandidates);
-        String candidateOrder = cGen.generateRandomCandidateOrder(); // returned by generator
+        List<Integer> candidateOrder = cGen.generateRandomCandidateOrder(); // returned by generator
 
         //store candidate in the random order
         for (int i = 0; i < numCandidates; i++) {
-            this.candidateList.add(candidates.get(Character.getNumericValue(candidateOrder.charAt(i))));
+            this.candidateList.add(candidates.get(candidateOrder.get(i)));
         }
 
         // call generator to randomly mark each candidate once
         PremarkGenerator pGen = new PremarkGenerator(numCandidates);
         boolean[][] premarked = pGen.generateMarks();
 
-        firstBallot = new Ballot(numCandidates, candidateOrder, premarked[0], orderKeys);
-        secondBallot = new Ballot(numCandidates, candidateOrder, premarked[1], orderKeys);
-        thirdBallot = new Ballot(numCandidates, candidateOrder, premarked[2], orderKeys);
+        firstBallot = new Ballot(numCandidates, candidateOrder.toString(), premarked[0], orderKeys);
+        secondBallot = new Ballot(numCandidates, candidateOrder.toString(), premarked[1], orderKeys);
+        thirdBallot = new Ballot(numCandidates, candidateOrder.toString(), premarked[2], orderKeys);
     }
 
     public Ballot getFirstBallot() {

--- a/src/main/java/org/sysc4907/votingsystem/Elections/Election.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/Election.java
@@ -172,12 +172,12 @@ public class Election {
         String responseData = "";
         if (!fabricEnabled) {
             String jsonString = "[" +
-                    "{\"ballotId\":\"1\",\"ballotMarks\":\"[true,false,true]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
-                    "{\"ballotId\":\"2\",\"ballotMarks\":\"[true,true,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
-                    "{\"ballotId\":\"3\",\"ballotMarks\":\"[false,false,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
-                    "{\"ballotId\":\"4\",\"ballotMarks\":\"[true,true,true]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
-                    "{\"ballotId\":\"5\",\"ballotMarks\":\"[false,true,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
-                    "{\"ballotId\":\"6\",\"ballotMarks\":\"[false,false,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}]";
+                    "{\"ballotId\":\"1\",\"ballotMarks\":\"[true,false,true]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}," +
+                    "{\"ballotId\":\"2\",\"ballotMarks\":\"[true,true,false]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}," +
+                    "{\"ballotId\":\"3\",\"ballotMarks\":\"[false,false,false]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}," +
+                    "{\"ballotId\":\"4\",\"ballotMarks\":\"[true,true,true]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}," +
+                    "{\"ballotId\":\"5\",\"ballotMarks\":\"[false,true,false]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}," +
+                    "{\"ballotId\":\"6\",\"ballotMarks\":\"[false,false,false]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}]";
             System.out.println("WARNING: using mocked blockchain response!");
             return new JSONArray(jsonString);
         }

--- a/src/main/java/org/sysc4907/votingsystem/Elections/Tally.java
+++ b/src/main/java/org/sysc4907/votingsystem/Elections/Tally.java
@@ -9,7 +9,9 @@ import org.json.JSONObject;
 
 import java.security.PrivateKey;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Tally {
     private final List<Integer> tallyOfVotes = new ArrayList<>();
@@ -85,11 +87,11 @@ public class Tally {
                 }
             }
         } // if fabric is not enabled we are using mocked data
-        List<Integer> order = new ArrayList<>();
-        for (char digitChar : decryptedOrder.toCharArray()) {
-            order.add(Character.getNumericValue(digitChar));
-        }
-        return order;
+
+        String[] parts = decryptedOrder.split(":");
+        String orderString = parts[0];
+        return Arrays.stream(orderString.replaceAll("[\\[\\]]", "").split(", "))
+                .map(Integer::parseInt).collect(Collectors.toList());
     }
 
     public List<Integer> getTallyOfVotes() {return tallyOfVotes;}

--- a/src/main/java/org/sysc4907/votingsystem/generators/CandidateOrderGenerator.java
+++ b/src/main/java/org/sysc4907/votingsystem/generators/CandidateOrderGenerator.java
@@ -5,13 +5,13 @@ import java.util.Collections;
 import java.util.List;
 
 public class CandidateOrderGenerator {
-    private int numberOfCandidates;
+    private final int numberOfCandidates;
 
     public CandidateOrderGenerator(int numberOfCandidates) {
         this.numberOfCandidates = numberOfCandidates;
     }
 
-    public String generateRandomCandidateOrder() {
+    public List<Integer> generateRandomCandidateOrder() {
         List<Integer> numbers = new ArrayList<>();
 
         // Add numbers from 0 to n to the list
@@ -22,12 +22,8 @@ public class CandidateOrderGenerator {
         // Shuffle the list to get a random order
         Collections.shuffle(numbers);
 
-        // Convert the list to a single string
-        String result = "";
-        for (int num : numbers) {
-            result += num;
-        }
 
-        return result;
+
+        return numbers;
     }
 }

--- a/src/main/resources/templates/three-ballot.html
+++ b/src/main/resources/templates/three-ballot.html
@@ -199,10 +199,6 @@
             finalizeReceiptButton.style.display = 'none';
             document.getElementById('receipt-button-container').style.display = 'none';
 
-            // Hide the help link
-            const helpLink = document.querySelector('.help-link');
-            helpLink.style.display = 'none';
-
             submitAllBallots();
         }
 

--- a/src/test/java/org/sysc4907/votingsystem/BallotTest.java
+++ b/src/test/java/org/sysc4907/votingsystem/BallotTest.java
@@ -7,7 +7,10 @@ import org.sysc4907.votingsystem.Ballots.ThreeBallot;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -60,19 +63,10 @@ public class BallotTest {
 
     @Test
     public void testEncryptAndDecrypt() throws Exception {
-        String data = "54321";
+        List<Integer> nums = new ArrayList<>(Arrays.asList(1,2,3,4,5));
+        String data = nums.toString();
         String encrypted = Ballot.encrypt(data, publicKey);
         String decrypted = Ballot.decrypt(encrypted, privateKey);
         assertEquals(data, decrypted);
-    }
-
-    @Test
-    public void testOrderObfuscation() {
-        int order = 132;
-        int moduloNumber = 555;
-        int obfuscated = order + 555 * (int)(Math.random() * 10);
-        int deObfuscated = obfuscated % moduloNumber;
-
-        assertEquals(132, deObfuscated);
     }
 }

--- a/src/test/java/org/sysc4907/votingsystem/TallyTest.java
+++ b/src/test/java/org/sysc4907/votingsystem/TallyTest.java
@@ -20,12 +20,12 @@ public class TallyTest {
     private Environment environment;
     Tally tally;
     String jsonString = "[" +
-            "{\"ballotId\":\"1\",\"ballotMarks\":\"[true,false,true]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
-            "{\"ballotId\":\"2\",\"ballotMarks\":\"[true,true,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
-            "{\"ballotId\":\"3\",\"ballotMarks\":\"[false,false,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
-            "{\"ballotId\":\"4\",\"ballotMarks\":\"[true,true,true]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
-            "{\"ballotId\":\"5\",\"ballotMarks\":\"[false,true,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}," +
-            "{\"ballotId\":\"6\",\"ballotMarks\":\"[false,false,false]\",\"candidateOrder\":\"102\",\"ring\":\"31\"}]";
+            "{\"ballotId\":\"1\",\"ballotMarks\":\"[true,false,true]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}," +
+            "{\"ballotId\":\"2\",\"ballotMarks\":\"[true,true,false]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}," +
+            "{\"ballotId\":\"3\",\"ballotMarks\":\"[false,false,false]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}," +
+            "{\"ballotId\":\"4\",\"ballotMarks\":\"[true,true,true]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}," +
+            "{\"ballotId\":\"5\",\"ballotMarks\":\"[false,true,false]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}," +
+            "{\"ballotId\":\"6\",\"ballotMarks\":\"[false,false,false]\",\"candidateOrder\":\"[1, 0, 2]\",\"ring\":\"31\"}]";
     JSONArray mockTransactions = new JSONArray(jsonString);
     List<java.security.PrivateKey> privateKeys = new ArrayList<>();
     List<String> candidateList = new ArrayList<>(Arrays.asList("foo", "bar", "baz"));

--- a/src/test/java/org/sysc4907/votingsystem/ThreeBallotTest.java
+++ b/src/test/java/org/sysc4907/votingsystem/ThreeBallotTest.java
@@ -29,23 +29,26 @@ public class ThreeBallotTest {
         assertEquals(4, b2.getMarkValues().length);
         assertEquals(4, b3.getMarkValues().length);
 
-        // candidate order is 4 digits and contains 0, 1, 2, 3 in any order
+        // candidate order is 4 digits and contains [0, 1, 2, 3] in any order
         String candidateOrder1 = b1.getEncryptedCandidateOrder();
-        assertEquals(4, candidateOrder1.length());
+        int lenghtOfNonNumChars = 8; //brackets commas and spaces
+        int expectedLenght = 4 + lenghtOfNonNumChars;
+        assertEquals(expectedLenght, candidateOrder1.length());
         assertTrue(candidateOrder1.contains("0"));
         assertTrue(candidateOrder1.contains("1"));
         assertTrue(candidateOrder1.contains("2"));
+
         assertTrue(candidateOrder1.contains("3"));
 
         String candidateOrder2 = b2.getEncryptedCandidateOrder();
-        assertEquals(4, candidateOrder2.length());
+        assertEquals(expectedLenght, candidateOrder2.length());
         assertTrue(candidateOrder2.contains("0"));
         assertTrue(candidateOrder2.contains("1"));
         assertTrue(candidateOrder2.contains("2"));
         assertTrue(candidateOrder2.contains("3"));
 
         String candidateOrder3 = b3.getEncryptedCandidateOrder();
-        assertEquals(4, candidateOrder3.length());
+        assertEquals(expectedLenght, candidateOrder3.length());
         assertTrue(candidateOrder3.contains("0"));
         assertTrue(candidateOrder3.contains("1"));
         assertTrue(candidateOrder3.contains("2"));


### PR DESCRIPTION
## PR type

- [ ] Feature
- [ ] Bug Fix
- [X] Refactor
- [ ] Performance Optimization
- [ ] Documentation Update

## Description
<!--
A description of what this PR is, not how it does what it is supposed to do.
-->
old method for random candidate order has been removed as it only worked for up to 10 candidates.
candidate order is now encrypted with salt.

## Related Issues/Tickets
<!--
If this PR is related to a ticket/issue, include it here.
For github issues the format is as follows: "closes #1234" which would automatically close the github issue
For Jira, link the ticket.
-->
- Jira ticket:
- Related Issue #
- Closes #49 
## QA Instruction, Screenshots etc...
<!--
Information on how to run/test the changes in the PR.
Include expected/actual results here as well.
-->

## Added/updated tests?

- [X] Yes
- [ ] No: _replace this line with details on why tests are not included in this PR_

## PR Checklist

- [X] I have rebased this branch against develop/latest
- [X] All the tests are passing
- [X] My commit messages are descriptive and usefull
