### PR TITLE
Functioning toggle of signing key autofill

### DIFF
--- a/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallotController.java
+++ b/src/main/java/org/sysc4907/votingsystem/Ballots/ThreeBallotController.java
@@ -59,6 +59,9 @@ public class ThreeBallotController {
 
         if (session.getAttribute("validKey") != null) { // if key has already been verified we don't need to display the pop-up again
             model.addAttribute("validKey", true); // adding this attribute will ensure it's not visible
+        } else {
+            // passing in one of the generated keys for auto-fill purposes (demo-only)
+            model.addAttribute("autoFillKey", FileHelper.getFileContents("./lirisi-generated-files/priv/1.pem"));
         }
 
         List<String> candidates = electionService.getElection().getCandidates();

--- a/src/main/resources/templates/three-ballot.html
+++ b/src/main/resources/templates/three-ballot.html
@@ -325,7 +325,7 @@
                 keyInput.value = `[[${autoFillKey}]]`;
                 keyInput.readOnly = true;
             } else {
-                keyInput.value = "";
+                keyInput.value = ""; // toggling back will clear the text, an improvement would be to keep whatever was there before the toggle!
                 keyInput.readOnly = false;
             }
         }
@@ -439,11 +439,17 @@
 
     <div th:if="!${validKey}" class="keyModal">
         <div class="pop-up-container">
-            <h2>Please Enter Your Signing Key</h2>
-            <label class="switch">
-                <input type="checkbox" onchange="autoFillSigningKey(this)">
-                <span class="slider round"></span>
-            </label>
+            <div style="display: flex; gap: 30px;  align-items: center; justify-content: center">
+                <h2>Please enter signing key</h2>
+                <div style="display: flex; gap: 10px; align-items: center;">
+                    <p>Auto-fill</p>
+                    <label class="switch">
+                        <input type="checkbox" onchange="autoFillSigningKey(this)">
+                        <span class="slider round"></span>
+                    </label>
+                </div>
+            </div>
+
             <div th:if="${errorMessage}" class="error-message" th:text="${errorMessage}"></div>
             <form id="signingKeyForm" th:action="@{/verify-signing-key}" method="post">
                 <div class="form-group">

--- a/src/main/resources/templates/three-ballot.html
+++ b/src/main/resources/templates/three-ballot.html
@@ -45,8 +45,71 @@
             align-items: center;
             margin: 20px;
         }
+        #signingKeyInput:read-only {
+            color: #777777;
+        }
+        .switch {
+            position: relative;
+            display: inline-block;
+            width: 60px;
+            height: 34px;
+        }
+
+        .switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+
+        .slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: #ccc;
+            -webkit-transition: .4s;
+            transition: .4s;
+        }
+
+        .slider:before {
+            position: absolute;
+            content: "";
+            height: 26px;
+            width: 26px;
+            left: 4px;
+            bottom: 4px;
+            background-color: white;
+            -webkit-transition: .4s;
+            transition: .4s;
+        }
+
+        input:checked + .slider {
+            background-color: #2196F3;
+        }
+
+        input:focus + .slider {
+            box-shadow: 0 0 1px #2196F3;
+        }
+
+        input:checked + .slider:before {
+            -webkit-transform: translateX(26px);
+            -ms-transform: translateX(26px);
+            transform: translateX(26px);
+        }
+
+        /* Rounded sliders */
+        .slider.round {
+            border-radius: 34px;
+        }
+
+        .slider.round:before {
+            border-radius: 50%;
+        }
     </style>
     <script>
+
         function finalizeCandidate() {
             // Disable all checkboxes
             const ballotBoxes = document.querySelectorAll('.ballot-box');
@@ -254,6 +317,18 @@
             finalizeButton.style.background = 'gray';
             finalizeButton.style.cursor = 'not-allowed';
         }
+
+        function autoFillSigningKey(toggle) {
+            const keyInput = document.getElementById('signingKeyInput');
+            if (toggle.checked) {
+                // filling the text area with one of the generated signatures (demo purposes only)
+                keyInput.value = `[[${autoFillKey}]]`;
+                keyInput.readOnly = true;
+            } else {
+                keyInput.value = "";
+                keyInput.readOnly = false;
+            }
+        }
     </script>
 
 </head>
@@ -365,6 +440,10 @@
     <div th:if="!${validKey}" class="keyModal">
         <div class="pop-up-container">
             <h2>Please Enter Your Signing Key</h2>
+            <label class="switch">
+                <input type="checkbox" onchange="autoFillSigningKey(this)">
+                <span class="slider round"></span>
+            </label>
             <div th:if="${errorMessage}" class="error-message" th:text="${errorMessage}"></div>
             <form id="signingKeyForm" th:action="@{/verify-signing-key}" method="post">
                 <div class="form-group">


### PR DESCRIPTION
## PR type

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Performance Optimization
- [ ] Documentation Update

## Description
<!--
A description of what this PR is, not how it does what it is supposed to do.
-->
I have created a toggle button that will autofill the content of the the text area to include the first generated signing key.
During the demo, users will be able to visibly see a key so we can highlight our usage of ring signatures, without being required to type it out themselves.

Note: This feature is for demo-purposes only, and would ultimately be removed for the final product.

## Related Issues/Tickets
<!--
If this PR is related to a ticket/issue, include it here.
For github issues the format is as follows: "closes #1234" which would automatically close the github issue
For Jira, link the ticket.
--> 
- Closes #93 
## QA Instruction, Screenshots etc...
<!--
Information on how to run/test the changes in the PR.
Include expected/actual results here as well.
-->
NOTE: This was **NOT** tested on the blockchain!! Please ensure to verify behaviour with it **enabled** for thorough testing!
Verify that signing key is still working as before using the auto-fill value.
Verify that entering the key manually still works properly.
Verify that toggling it back, clears the content and makes the text area editable again.

![image](https://github.com/user-attachments/assets/4274872b-72a3-4e55-9a0c-c8fad0281508)

Once toggled, text area is filled with the key and is read-only.
![image](https://github.com/user-attachments/assets/38a76a48-90bc-4e2e-8289-056190ef4c9f)


## Added/updated tests?

- [ ] Yes
- [x] No: This is a front-end change for the demo, I don't see the need for additional automated testing.

## PR Checklist

- [ ] I have rebased this branch against develop/latest
- [x] All the tests are passing
- [x] My commit messages are descriptive and usefull
