### PR TITLE
[Need to Rebase] Logout/Register Buttons for non-logged in users

### DIFF
--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -29,7 +29,15 @@ body {
     align-items: center;
     margin: 20px;
     gap: 10px;
-    color: var(--main-purple-color);
+}
+
+.login-register {
+    width: fit-content;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin: 20px;
+    gap: 10px;
 }
 
 header {

--- a/src/main/resources/templates/election-details.html
+++ b/src/main/resources/templates/election-details.html
@@ -124,6 +124,10 @@
             </button>
         </form >
     </div>
+    <div class="login-register" th:if="!${username}">
+        <button onclick="window.location.href='/home'">Login</button>
+        <button onclick="window.location.href='/registration-key'">Register</button>
+    </div>
     <div th:if="${errorMessage}" class="error-message" th:text="${errorMessage}"></div>
 </header>
 

--- a/src/main/resources/templates/election-details.html
+++ b/src/main/resources/templates/election-details.html
@@ -124,7 +124,7 @@
             </button>
         </form >
     </div>
-    <div class="login-register" th:if="!${username}">
+    <div class="login-register" sec:authorize="isAnonymous()">
         <button onclick="window.location.href='/home'">Login</button>
         <button onclick="window.location.href='/registration-key'">Register</button>
     </div>

--- a/src/main/resources/templates/home-page.html
+++ b/src/main/resources/templates/home-page.html
@@ -30,7 +30,6 @@
       <a th:if="${electionName}" href="/ledger">Ledger</a>
       <a th:if="${electionName}" href="/">Election Results (update link!)</a>
     </nav>
-<<<<<<< HEAD
     <div class="user-details" sec:authorize="isAuthenticated()">
       <i class="fa-solid fa-circle-user"></i>
       <p sec:authentication="name"></p>

--- a/src/main/resources/templates/home-page.html
+++ b/src/main/resources/templates/home-page.html
@@ -30,6 +30,7 @@
       <a th:if="${electionName}" href="/ledger">Ledger</a>
       <a th:if="${electionName}" href="/">Election Results (update link!)</a>
     </nav>
+<<<<<<< HEAD
     <div class="user-details" sec:authorize="isAuthenticated()">
       <i class="fa-solid fa-circle-user"></i>
       <p sec:authentication="name"></p>
@@ -43,6 +44,11 @@
           </div>
         </button>
       </form >
+    </div>
+
+    <div class="login-register" sec:authorize="isAnonymous()">
+      <button onclick="window.location.href='/home'">Login</button>
+      <button onclick="window.location.href='/registration-key'">Register</button>
     </div>
 </header>
 

--- a/src/main/resources/templates/instructions.html
+++ b/src/main/resources/templates/instructions.html
@@ -83,7 +83,7 @@
             </button>
         </form >
     </div>
-    <div class="login-register" th:if="!${username}">
+    <div class="login-register" sec:authorize="isAnonymous()">
         <button onclick="window.location.href='/home'">Login</button>
         <button onclick="window.location.href='/registration-key'">Register</button>
     </div>

--- a/src/main/resources/templates/instructions.html
+++ b/src/main/resources/templates/instructions.html
@@ -83,6 +83,10 @@
             </button>
         </form >
     </div>
+    <div class="login-register" th:if="!${username}">
+        <button onclick="window.location.href='/home'">Login</button>
+        <button onclick="window.location.href='/registration-key'">Register</button>
+    </div>
 </header>
 <main>
     <h1>3-Ballot Voting System</h1>

--- a/src/main/resources/templates/ledger-all-votes.html
+++ b/src/main/resources/templates/ledger-all-votes.html
@@ -116,7 +116,7 @@
             </button>
         </form >
     </div>
-    <div class="login-register" th:if="!${username}">
+    <div class="login-register" sec:authorize="isAnonymous()">
         <button onclick="window.location.href='/home'">Login</button>
         <button onclick="window.location.href='/registration-key'">Register</button>
     </div>

--- a/src/main/resources/templates/ledger-all-votes.html
+++ b/src/main/resources/templates/ledger-all-votes.html
@@ -116,6 +116,10 @@
             </button>
         </form >
     </div>
+    <div class="login-register" th:if="!${username}">
+        <button onclick="window.location.href='/home'">Login</button>
+        <button onclick="window.location.href='/registration-key'">Register</button>
+    </div>
 </header>
 <main>
     <h1 th:if="${election}" th:text="|Ledger for Election: ${election.NAME}|" style="color: var(--logo-writing-color);"></h1>


### PR DESCRIPTION
## PR type

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Performance Optimization
- [ ] Documentation Update

## Description
<!--
A description of what this PR is, not how it does what it is supposed to do.
-->
Adding Login/Register buttons in the corner of the header for any publically facing page when a user is not logged in.
## Related Issues/Tickets
<!--
If this PR is related to a ticket/issue, include it here.
For github issues the format is as follows: "closes #1234" which would automatically close the github issue
For Jira, link the ticket.
-->
- Jira ticket:
- Related Issue #
- Closes #117 
## QA Instruction, Screenshots etc...
<!--
Information on how to run/test the changes in the PR.
Include expected/actual results here as well.
-->
![image](https://github.com/user-attachments/assets/cff5d9c8-4805-40aa-bfa3-8394b1bf1046)
Verify presence of these buttons on public pages when user is logged in.
* landing page
* election details
* ledger
Should see the usual username/logout if user is logged in.

## Added/updated tests?

- [ ] Yes
- [x] No: front-end change

## PR Checklist

- [x] I have rebased this branch against develop/latest
- [ ] All the tests are passing
- [x] My commit messages are descriptive and usefull
